### PR TITLE
Fix for bash arithmetic bug

### DIFF
--- a/regul.sh
+++ b/regul.sh
@@ -9,6 +9,14 @@ do
 	echo TEMP REGULATION IS ACTIVE
 	temp1=$(cgminer-api stats | grep temp1] | awk '{print $3}') 
 	temp2=$(cgminer-api stats | grep temp2] | awk '{print $3}')
+        if ! [ "$temp1" -eq "$temp1" ] 2> /dev/null || ! [ "$temp2" -eq "$temp2" ] 2> /dev/null
+	then
+		echo "Warning: temp1 or temp2 not an integer! Waiting 60s."
+                echo "temp1: $temp1"
+		echo "temp2: $temp2"
+		sleep 60 # Wait 60 seconds. Cgminer is probably restarting.
+		continue # Go to next loop iteration.
+	fi
 	maxtemp=$(( $temp1 > $temp2 ? $temp1 : $temp2 ))
 	echo Temperature: $maxtemp
 	freq=$(cgminer-api stats | grep frequency] | awk '{print $3}')


### PR DESCRIPTION
Code to fix bash arithmetic bug. When the machine is restarting, for example when you manually change a setting, and at the same time the regul.sh script is running, then an error can occur causing the regul.sh script to exit.

The code producing the error is `temp1=$(cgminer-api stats | grep temp1] | awk '{print $3}')` which, during restarts, can produce a non-integer into the variable `$temp1`. The code in this patch fixes this error. The error takes place during `maxtemp=$(( $temp1 > $temp2 ? $temp1 : $temp2 ))`. The error is: `-sh: arithmetic syntax error`.
